### PR TITLE
fix: :bug: There was a overlapping that was happening in valid props section in CoreComponent documentation

### DIFF
--- a/app/components/ComponentProps.js
+++ b/app/components/ComponentProps.js
@@ -27,7 +27,7 @@ export default function ComponentProps(props) {
 
         {title === "Valid Props" && <CoreSelect
           gridProps={{ gridSize: { md: 12 } }}
-          label="View props"
+          // label="View props"
           id="viewPropsData"
           value={viewPropsData}
           handleChange={(event) => handleSelectChange(event)}


### PR DESCRIPTION
## Description

This error was occuring due to the lable which i have commented now which was placed in CoreSelect component. This error has been solved.

Ref: #160


**Image of solution
![Screenshot 2024-08-07 191930](https://github.com/user-attachments/assets/114262d9-ae20-4403-8b0a-53bf34792a71)

