### PR TITLE
fix(core): :bug: CoreItemListText  documentation has been updated and the props is visible now

### DIFF
--- a/app/components/component-docs/dataDisplay/CoreListItemText.docs.js
+++ b/app/components/component-docs/dataDisplay/CoreListItemText.docs.js
@@ -9,33 +9,50 @@ import {
   CoreClasses
 } from "@wrappid/core";
   
+import CodeImport from "../../CodeImport";
 import CodeSample from "../../CodeSample";
+import ComponentProps from "../../ComponentProps";
 
 export default function CoreListItemTextDocs() {
   return (
     <>
       <CoreH4>CoreListItemText</CoreH4>
   
-      <CoreTypographyBody1>
-          COMPONENT_DESCRIPTION
+      <CoreTypographyBody1 styleClasses={[CoreClasses.PADDING.PT2]}>
+          CoreListItemText is a component in Wrappid that is used to display text within a CoreListItem. It typically contains the primary content of the CoreListItem, such as the main label or description. The component is designed to handle different text configurations and can display primary and secondary text, such as a title and a subtitle.
       </CoreTypographyBody1>
-  
+      
+      <CodeImport name="CoreListItemIcon" />
+      
       <CodeSample
-        title={"Basic CoreListItemText"}
-        description={"DESCRIPTION_OF_THE_SAMPLE"}
+        title={"Basic Description"}
+        description={<>
+          <CoreBox styleClasses={[CoreClasses.PADDING.PL2]}>
+            
+            <CoreList variant="HTML" listType="DISC">
+              <CoreListItem>
+                <CoreListItemText primary="Primary Text: The main text of the CoreListItem, often displayed in a more prominent style."/>
+              </CoreListItem>
+
+              <CoreListItem>
+                <CoreListItemText primary="Secondary Text: An optional additional line of text, typically displayed in a lighter or smaller font."/>
+              </CoreListItem>
+            </CoreList>
+          </CoreBox>
+        </>}
         code={`<CoreBox
 styleClasses={[CoreClasses.WIDTH.W_100.MAX_W_100, CoreClasses.BORDER.BORDER_2]}
 >
   <CoreList>
     <CoreListItem disablePadding>
       <CoreListItemButton>
-        <CoreListItemText primary="Trash" />
+        <CoreListItemText primary="primary" />
       </CoreListItemButton>
     </CoreListItem>
 
     <CoreListItem disablePadding>
       <CoreListItemButton component="a" href="#simple-Corelist">
-        <CoreListItemText primary="Spam" />
+        <CoreListItemText secondary="secondary" />
       </CoreListItemButton>
     </CoreListItem>
   </CoreList>
@@ -50,13 +67,13 @@ styleClasses={[CoreClasses.WIDTH.W_100.MAX_W_100, CoreClasses.BORDER.BORDER_2]}
               <CoreList>
                 <CoreListItem disablePadding>
                   <CoreListItemButton>
-                    <CoreListItemText primary="Trash" />
+                    <CoreListItemText primary="primary" />
                   </CoreListItemButton>
                 </CoreListItem>
 
                 <CoreListItem disablePadding>
                   <CoreListItemButton component="a" href="#simple-Corelist">
-                    <CoreListItemText primary="Spam" />
+                    <CoreListItemText secondary="secondary" />
                   </CoreListItemButton>
                 </CoreListItem>
               </CoreList>
@@ -66,7 +83,8 @@ styleClasses={[CoreClasses.WIDTH.W_100.MAX_W_100, CoreClasses.BORDER.BORDER_2]}
           </>
         }
       />
-      
+
+      <ComponentProps component={CoreListItemText} />
     </>
   );
 }


### PR DESCRIPTION
## Description

-the CoreItemListText documentation which was not given properly is now given properly
-the props that was not appearing is now appearing

**Image**

![Screenshot 2024-08-17 181747](https://github.com/user-attachments/assets/f729d5e1-6028-4cb8-8a23-32428f253521)
![Screenshot 2024-08-17 181813](https://github.com/user-attachments/assets/9ff30c06-cc7f-4b4f-9b69-d75f51a77c7b)


Ref: #196


