### PR TITLE
docs(global): :memo: corecontainer documentation fixed

### DIFF
--- a/app/components/component-docs/layouts/CoreContainer.docs.js
+++ b/app/components/component-docs/layouts/CoreContainer.docs.js
@@ -1,51 +1,72 @@
+
 import {
-  CoreH4,
-  CoreTypographyBody1
+  CoreBox,
+  CoreClasses,
+  CoreContainer
 } from "@wrappid/core";
   
 import CodeSample from "../../CodeSample";
+import ComponentDocs from "../ComponentDocs";
 
 export default function CoreContainerDocs() {
   return (
-    <>
-      <CoreH4>CoreContainer</CoreH4>
-  
-      <CoreTypographyBody1>
-        {"The container centers your content horizontally. It's the most basic layout element."}
-      </CoreTypographyBody1>
-
-      <CoreTypographyBody1>
-      While containers can be nested, most layouts do not require a nested container.
-      </CoreTypographyBody1>
-  
-      <CodeSample
-        title={"Fluid(NOT_WORKING)"}
-        description={"A fluid container width is bounded by the maxWidth prop value."}
-        code={`
-<CoreContainer maxWidth="sm">
-  <CoreBox styleClasses={[CoreClasses.BG.BG_PRIMARY_DARK, CoreClasses.HEIGHT.H_75]} />
-</CoreContainer>
-        `}
-        renderElement={<>
-
-        </>}
-      />
-
-      <CodeSample
-        title={"Fixed(NOT_WORKING)"}
-        description={"If you prefer to design for a fixed set of sizes instead of trying to accommodate a fully fluid viewport, you can set the fixed prop. The max-width matches the min-width of the current breakpoi"}
-        code={`
-<CoreContainer fixed>
-    <CoreBox styleClasses={[CoreClasses.BG.BG_PRIMARY_DARK, CoreClasses.HEIGHT.H_75]} />
+    <ComponentDocs
+      component={CoreContainer}
+      description="The container centers your content horizontally. It's the most basic layout element."
+      samples={
+        <>
+          <CodeSample
+            title={"Fluid"}
+            description="A fluid container width is bounded by the maxWidth prop value."
+            code={`<CoreContainer maxWidth="sm">
+  <CoreBox height="500px" styleClasses={[CoreClasses.BG.BG_INFO]} />
 </CoreContainer>`}
-        renderElement={<>
-          
-        </>}
-      />
-        
-      {/* eslint-disable-next-line etc/no-commented-out-code */}
-      {/* <ComponentProps component={CoreContainer} /> */}
-      
-    </>
+            expandedCode={`import { CoreBox, CoreClasses, CoreContainer } from "@wrappid/core";
+
+export default function BasicCoreBox() {
+
+  return (
+    <CoreContainer maxWidth="sm">
+      <CoreBox height="500px" styleClasses={[CoreClasses.BG.BG_INFO]} />
+    </CoreContainer>
+  );
+}`}
+            renderElement={
+              <CoreContainer maxWidth="sm">
+                <CoreBox height="500px" styleClasses={[CoreClasses.BG.BG_INFO]} />
+              </CoreContainer>
+            }
+          />
+
+          <CodeSample
+            title={"Fixed"}
+            description="If you prefer to design for a fixed set of sizes instead of trying to accommodate a fully fluid viewport, you can set the fixed prop. The max-width matches the min-width of the current breakpoint"
+            code={`<CoreContainer fixed>
+  <CoreBox height="30rem" styleClasses={[CoreClasses.BG.BG_PRIMARY_DARK]} />
+</CoreContainer>`}
+            expandedCode={`import { CoreBox, CoreClasses, CoreContainer } from "@wrappid/core";
+
+export default function BasicCoreBox() {
+
+  return (
+    <CoreBox styleClasses={[CoreClasses.WIDTH.W_50]}>
+      <CoreContainer fixed>
+        <CoreBox height="30rem" styleClasses={[CoreClasses.BG.BG_PRIMARY_DARK]} />
+      </CoreContainer>
+    </CoreBox>
+  );
+}`}
+            renderElement={
+              <CoreBox styleClasses={[CoreClasses.WIDTH.W_50]}>
+                <CoreContainer fixed>
+                  <CoreBox height="30rem" styleClasses={[CoreClasses.BG.BG_PRIMARY_DARK]} />
+                </CoreContainer>
+              </CoreBox>
+            }
+          />
+        </>
+      }
+    />
+
   );
 }


### PR DESCRIPTION
## Description

- [x] the documentation was not given properly,  

- [x] fluid and fixed were not working properly 

- [x] documentation need to be done according to the new format

**Image**

![image](https://github.com/user-attachments/assets/9949d45b-1bd7-421b-b526-cbaad71721ef)

Ref: #276

